### PR TITLE
[code]: typo fixes for month

### DIFF
--- a/lib/src/nepali_date_format.dart
+++ b/lib/src/nepali_date_format.dart
@@ -348,7 +348,7 @@ class NepaliDateFormat {
       _Month('Bhadra', 'Bha'),
       _Month('Ashwin', 'Ash'),
       _Month('Kartik', 'Kar'),
-      _Month('Mangsir', 'Marg'),
+      _Month('Mangsir', 'Mang'),
       _Month('Poush', 'Pou'),
       _Month('Magh', 'Mag'),
       _Month('Falgun', 'Fal'),


### PR DESCRIPTION
Thank you @sarbagyastha brother for the package...
As I was using `showMaterialDateRangePicker()` from the `nepali_date_picker` package, I found a typo for the short form of `Mangsir` which was `Marg` instead of `Mang`. This pr fixes the typo for this month. 