### PR TITLE
Delimiter Added in case of Number format

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -72,14 +72,12 @@ void main(List<String> arguments) {
   print('123456789.6548 -> ${currencyInWords.format(123456789.6548)}');
 
   heading('With Empty Delimiter');
-  print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
   print('1234 -> ${currencyFormatWithNoDelimiter.format(1234)}');
   print('12345 -> ${currencyFormatWithNoDelimiter.format(12345)}');
   print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
   print('123456789.6548 -> ${delimiterWithDecimal.format(123456789.6548)}');
 
   heading('With Delimiter');
-  print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');
   print('1234 -> ${currencyFormatWithDelimiter.format(1234)}');
   print('12345 -> ${currencyFormatWithDelimiter.format(12345)}');
   print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');

--- a/example/main.dart
+++ b/example/main.dart
@@ -32,25 +32,19 @@ void main(List<String> arguments) {
   print(date5.format(gorkhaEarthQuake));
 
   heading('Nepali Number Format');
-  var currencyFormat = NepaliNumberFormat(
+  final numberFormat = NepaliNumberFormat(
     symbol: 'Rs.',
   );
-  var commaSeparated = NepaliNumberFormat(
+  final commaSeparated = NepaliNumberFormat(
     decimalDigits: 2,
   );
 
-  var currencyFormatWithDelimiterAndDecimal = NepaliNumberFormat(
-    decimalDigits: 2,
-  );
-  var currencyFormatWithDelimiter = NepaliNumberFormat(
+  final numberFormatWithDefaultDelimiter = NepaliNumberFormat(
     symbol: 'Rs.',
+    delimiter: ',',
   );
-  var currencyFormatWithNoDelimiter = NepaliNumberFormat(
+  final numberFormatWithEmptyDelimiter = NepaliNumberFormat(
     symbol: 'Rs.',
-    delimiter: '',
-  );
-  var delimiterWithDecimal = NepaliNumberFormat(
-    decimalDigits: 2,
     delimiter: '',
   );
 
@@ -66,23 +60,14 @@ void main(List<String> arguments) {
     language: Language.nepali,
     isMonetory: true,
   );
-  print('123456 -> ${currencyFormat.format(123456)}');
+  print('123456 -> ${numberFormat.format(123456)}');
   print('123456789.6548 -> ${commaSeparated.format(123456789.6548)}');
   print('123456 -> ${inWords.format(123456)}');
   print('123456789.6548 -> ${currencyInWords.format(123456789.6548)}');
 
-  heading('With Empty Delimiter');
-  print('1234 -> ${currencyFormatWithNoDelimiter.format(1234)}');
-  print('12345 -> ${currencyFormatWithNoDelimiter.format(12345)}');
-  print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
-  print('123456789.6548 -> ${delimiterWithDecimal.format(123456789.6548)}');
-
-  heading('With Delimiter');
-  print('1234 -> ${currencyFormatWithDelimiter.format(1234)}');
-  print('12345 -> ${currencyFormatWithDelimiter.format(12345)}');
-  print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');
-  print(
-      '1234567.891 -> ${currencyFormatWithDelimiterAndDecimal.format(1234567.891)}');
+  heading('Number Format With Delimiter');
+  print('12345 -> ${numberFormatWithDefaultDelimiter.format(12345)}');
+  print('12345 -> ${numberFormatWithEmptyDelimiter.format(12345)}');
 
   heading('Nepali Unicode');
   print(NepaliUnicode.convert(

--- a/example/main.dart
+++ b/example/main.dart
@@ -39,6 +39,15 @@ void main(List<String> arguments) {
     decimalDigits: 2,
   );
 
+  var currencyFormatHideComma = NepaliNumberFormat(
+    symbol: 'Rs.',
+    hideComma: true,
+  );
+  var hideComma = NepaliNumberFormat(
+    decimalDigits: 2,
+    hideComma: true,
+  );
+
   // Sets default language for nepali utilities to be Nepali.
   NepaliUtils(Language.nepali);
 
@@ -55,6 +64,13 @@ void main(List<String> arguments) {
   print('123456789.6548 -> ${commaSeparated.format(123456789.6548)}');
   print('123456 -> ${inWords.format(123456)}');
   print('123456789.6548 -> ${currencyInWords.format(123456789.6548)}');
+
+  heading('Hide Comma');
+  print('123456 -> ${currencyFormatHideComma.format(123456)}');
+  print('1234 -> ${currencyFormatHideComma.format(1234)}');
+  print('1234.5 -> ${currencyFormatHideComma.format(1234.5)}');
+  print('123456 -> ${currencyFormatHideComma.format(123456)}');
+  print('123456789.6548 -> ${hideComma.format(123456789.6548)}');
 
   heading('Nepali Unicode');
   print(NepaliUnicode.convert(

--- a/example/main.dart
+++ b/example/main.dart
@@ -39,13 +39,19 @@ void main(List<String> arguments) {
     decimalDigits: 2,
   );
 
-  var currencyFormatHideComma = NepaliNumberFormat(
-    symbol: 'Rs.',
-    hideComma: true,
-  );
-  var hideComma = NepaliNumberFormat(
+  var currencyFormatWithDelimiterAndDecimal = NepaliNumberFormat(
     decimalDigits: 2,
-    hideComma: true,
+  );
+  var currencyFormatWithDelimiter = NepaliNumberFormat(
+    symbol: 'Rs.',
+  );
+  var currencyFormatWithNoDelimiter = NepaliNumberFormat(
+    symbol: 'Rs.',
+    delimiter: '',
+  );
+  var delimiterWithDecimal = NepaliNumberFormat(
+    decimalDigits: 2,
+    delimiter: '',
   );
 
   // Sets default language for nepali utilities to be Nepali.
@@ -65,12 +71,20 @@ void main(List<String> arguments) {
   print('123456 -> ${inWords.format(123456)}');
   print('123456789.6548 -> ${currencyInWords.format(123456789.6548)}');
 
-  heading('Hide Comma');
-  print('123456 -> ${currencyFormatHideComma.format(123456)}');
-  print('1234 -> ${currencyFormatHideComma.format(1234)}');
-  print('1234.5 -> ${currencyFormatHideComma.format(1234.5)}');
-  print('123456 -> ${currencyFormatHideComma.format(123456)}');
-  print('123456789.6548 -> ${hideComma.format(123456789.6548)}');
+  heading('With Empty Delimiter');
+  print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
+  print('1234 -> ${currencyFormatWithNoDelimiter.format(1234)}');
+  print('12345 -> ${currencyFormatWithNoDelimiter.format(12345)}');
+  print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
+  print('123456789.6548 -> ${delimiterWithDecimal.format(123456789.6548)}');
+
+  heading('With Delimiter');
+  print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');
+  print('1234 -> ${currencyFormatWithDelimiter.format(1234)}');
+  print('12345 -> ${currencyFormatWithDelimiter.format(12345)}');
+  print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');
+  print(
+      '1234567.891 -> ${currencyFormatWithDelimiterAndDecimal.format(1234567.891)}');
 
   heading('Nepali Unicode');
   print(NepaliUnicode.convert(

--- a/lib/src/nepali_number_format.dart
+++ b/lib/src/nepali_number_format.dart
@@ -30,6 +30,11 @@ class NepaliNumberFormat {
   /// [isMonetory] is required to be set as true.
   final String? symbol;
 
+  /// If false, comma will be removed in the formatted string.
+  ///
+  /// Default is false.
+  final bool hideComma;
+
   /// If true, place the symbol on left side of the formatted number.
   ///
   /// Default is true.
@@ -57,6 +62,7 @@ class NepaliNumberFormat {
     this.decimalDigits,
     this.symbol,
     this.symbolOnLeft = true,
+    this.hideComma = false,
     this.spaceBetweenAmountAndSymbol = true,
     this.includeDecimalIfZero = true,
     Language? language,
@@ -71,8 +77,8 @@ class NepaliNumberFormat {
           : _formatInWords<T>(number);
     } else {
       return isMonetory
-          ? _placeSymbol(_formatWithComma<T>(number))
-          : _formatWithComma<T>(number);
+          ? _placeSymbol(_formatWithComma<T>(number, hideComma))
+          : _formatWithComma<T>(number, hideComma);
     }
   }
 
@@ -92,7 +98,7 @@ class NepaliNumberFormat {
   String _formatInWords<T extends Object>(T number) {
     var numberInWord = '';
     var decimal = '';
-    var commaFormattedNumber = _formatWithComma<T>(number);
+    var commaFormattedNumber = _formatWithComma<T>(number, hideComma);
     var digitGroups = commaFormattedNumber.split(',');
 
     if (commaFormattedNumber.contains('.')) {
@@ -182,7 +188,7 @@ class NepaliNumberFormat {
     }
   }
 
-  String _formatWithComma<T extends Object>(T number) {
+  String _formatWithComma<T extends Object>(T number, bool hideComma) {
     var _decimalDigits = decimalDigits;
     var _number = '', _fractionalPart = '';
     if (number is String) {
@@ -229,19 +235,26 @@ class NepaliNumberFormat {
       if (hideDecimal) {
         return '${localizedNum[0]},${localizedNum.substring(1)}';
       }
+      if (hideComma) {
+        return '$localizedNum$_fractionalPart';
+      }
       return '${localizedNum[0]},${localizedNum.substring(1)}$_fractionalPart';
     } else {
       var paddedNumber = _number.length.isOdd ? _number : '0$_number';
       var formattedString = '';
       var digitMatcher = RegExp(r'\d{1,2}');
       var matches = digitMatcher.allMatches(paddedNumber);
-      for (var i = 0; i < matches.length; i++) {
-        if (i < matches.length - 2) {
-          formattedString += '${matches.elementAt(i).group(0)},';
-        } else {
-          formattedString +=
-              _number.substring(_number.length - 3, _number.length);
-          break;
+      if (hideComma) {
+        formattedString = _number;
+      } else {
+        for (var i = 0; i < matches.length; i++) {
+          if (i < matches.length - 2) {
+            formattedString += '${matches.elementAt(i).group(0)},';
+          } else {
+            formattedString +=
+                _number.substring(_number.length - 3, _number.length);
+            break;
+          }
         }
       }
       formattedString = formattedString[0] == '0'

--- a/lib/src/nepali_number_format.dart
+++ b/lib/src/nepali_number_format.dart
@@ -30,7 +30,7 @@ class NepaliNumberFormat {
   /// [isMonetory] is required to be set as true.
   final String? symbol;
 
-  /// If false, comma will be removed in the formatted string.
+  /// If true, comma will be removed in the formatted string.
   ///
   /// Default is false.
   final bool hideComma;

--- a/lib/src/nepali_number_format.dart
+++ b/lib/src/nepali_number_format.dart
@@ -30,10 +30,14 @@ class NepaliNumberFormat {
   /// [isMonetory] is required to be set as true.
   final String? symbol;
 
-  /// If true, comma will be removed in the formatted string.
+  /// The character used to separate place value in number.
   ///
-  /// Default is false.
-  final bool hideComma;
+  /// i.e. 2000(delimiter = ',') -> 2,000
+  ///      2000(delimiter = '') -> 2000
+  ///      2000(delimiter = '.') -> 2.000
+  ///
+  /// Default value ','.
+  final String delimiter;
 
   /// If true, place the symbol on left side of the formatted number.
   ///
@@ -62,7 +66,7 @@ class NepaliNumberFormat {
     this.decimalDigits,
     this.symbol,
     this.symbolOnLeft = true,
-    this.hideComma = false,
+    this.delimiter = ',',
     this.spaceBetweenAmountAndSymbol = true,
     this.includeDecimalIfZero = true,
     Language? language,
@@ -77,8 +81,8 @@ class NepaliNumberFormat {
           : _formatInWords<T>(number);
     } else {
       return isMonetory
-          ? _placeSymbol(_formatWithComma<T>(number, hideComma))
-          : _formatWithComma<T>(number, hideComma);
+          ? _placeSymbol(_formatWithComma<T>(number))
+          : _formatWithComma<T>(number);
     }
   }
 
@@ -98,7 +102,7 @@ class NepaliNumberFormat {
   String _formatInWords<T extends Object>(T number) {
     var numberInWord = '';
     var decimal = '';
-    var commaFormattedNumber = _formatWithComma<T>(number, hideComma);
+    var commaFormattedNumber = _formatWithComma<T>(number);
     var digitGroups = commaFormattedNumber.split(',');
 
     if (commaFormattedNumber.contains('.')) {
@@ -188,7 +192,7 @@ class NepaliNumberFormat {
     }
   }
 
-  String _formatWithComma<T extends Object>(T number, bool hideComma) {
+  String _formatWithComma<T extends Object>(T number) {
     var _decimalDigits = decimalDigits;
     var _number = '', _fractionalPart = '';
     if (number is String) {
@@ -235,26 +239,19 @@ class NepaliNumberFormat {
       if (hideDecimal) {
         return '${localizedNum[0]},${localizedNum.substring(1)}';
       }
-      if (hideComma) {
-        return '$localizedNum$_fractionalPart';
-      }
-      return '${localizedNum[0]},${localizedNum.substring(1)}$_fractionalPart';
+      return '${localizedNum[0]}$delimiter${localizedNum.substring(1)}$_fractionalPart';
     } else {
       var paddedNumber = _number.length.isOdd ? _number : '0$_number';
       var formattedString = '';
       var digitMatcher = RegExp(r'\d{1,2}');
       var matches = digitMatcher.allMatches(paddedNumber);
-      if (hideComma) {
-        formattedString = _number;
-      } else {
-        for (var i = 0; i < matches.length; i++) {
-          if (i < matches.length - 2) {
-            formattedString += '${matches.elementAt(i).group(0)},';
-          } else {
-            formattedString +=
-                _number.substring(_number.length - 3, _number.length);
-            break;
-          }
+      for (var i = 0; i < matches.length; i++) {
+        if (i < matches.length - 2) {
+          formattedString += '${matches.elementAt(i).group(0)}$delimiter';
+        } else {
+          formattedString +=
+              _number.substring(_number.length - 3, _number.length);
+          break;
         }
       }
       formattedString = formattedString[0] == '0'

--- a/lib/src/nepali_number_format.dart
+++ b/lib/src/nepali_number_format.dart
@@ -36,7 +36,7 @@ class NepaliNumberFormat {
   ///      2000(delimiter = '') -> 2000
   ///      2000(delimiter = '.') -> 2.000
   ///
-  /// Default value ','.
+  /// Default value is ','.
   final String delimiter;
 
   /// If true, place the symbol on left side of the formatted number.
@@ -237,7 +237,7 @@ class NepaliNumberFormat {
     } else if (_number.length < 5) {
       var localizedNum = _isEnglish ? _number : NepaliUnicode.convert(_number);
       if (hideDecimal) {
-        return '${localizedNum[0]},${localizedNum.substring(1)}';
+        return '${localizedNum[0]}$delimiter${localizedNum.substring(1)}';
       }
       return '${localizedNum[0]}$delimiter${localizedNum.substring(1)}$_fractionalPart';
     } else {

--- a/test/nepali_number_format_test.dart
+++ b/test/nepali_number_format_test.dart
@@ -128,14 +128,29 @@ void main() {
   group('hide comma tests:', () {
     test(
       'default is english',
-      () => expect(NepaliNumberFormat(hideComma: true).format(1234), '1234'),
+      () => expect(NepaliNumberFormat(delimiter: '').format(1234), '1234'),
     );
     test(
       'formats in nepali',
       () => expect(
-        NepaliNumberFormat(language: Language.nepali, hideComma: true)
+        NepaliNumberFormat(language: Language.nepali, delimiter: '')
             .format(1234),
         '१२३४',
+      ),
+    );
+  });
+
+  group('hide comma tests:', () {
+    test(
+      'default is english',
+      () => expect(NepaliNumberFormat(delimiter: '*').format(1234), '1*234'),
+    );
+    test(
+      'formats in nepali',
+      () => expect(
+        NepaliNumberFormat(language: Language.nepali, delimiter: '*')
+            .format(1234),
+        '१*२३४',
       ),
     );
   });

--- a/test/nepali_number_format_test.dart
+++ b/test/nepali_number_format_test.dart
@@ -10,18 +10,18 @@ void main() {
 
     test(
       'throws error on bool',
-      () => expect(() => _format(true), throwsArgumentError),
+          () => expect(() => _format(true), throwsArgumentError),
     );
   });
 
   group('language tests:', () {
     test(
       'default is english',
-      () => expect(NepaliNumberFormat().format(1234), '1,234'),
+          () => expect(NepaliNumberFormat().format(1234), '1,234'),
     );
     test(
       'formats in nepali',
-      () => expect(
+          () => expect(
         NepaliNumberFormat(language: Language.nepali).format(1234),
         '१,२३४',
       ),
@@ -31,17 +31,17 @@ void main() {
   group('decimal digit tests:', () {
     test(
       'default is 0 for integer input',
-      () => expect(NepaliNumberFormat().format(1234), '1,234'),
+          () => expect(NepaliNumberFormat().format(1234), '1,234'),
     );
 
     test(
       'default is 2 for input type other than integer',
-      () => expect(NepaliNumberFormat().format(1234.0), '1,234.00'),
+          () => expect(NepaliNumberFormat().format(1234.0), '1,234.00'),
     );
 
     test(
       'formats decimal digits as per the decimalDigits value',
-      () => expect(
+          () => expect(
         NepaliNumberFormat(decimalDigits: 4).format(1234),
         '1,234.0000',
       ),
@@ -103,7 +103,7 @@ void main() {
   group('Formats in word tests:', () {
     test(
       'english language',
-      () => expect(
+          () => expect(
         NepaliNumberFormat(
           language: Language.english,
           inWords: true,
@@ -114,13 +114,28 @@ void main() {
 
     test(
       'nepali language',
-      () => expect(
+          () => expect(
         NepaliNumberFormat(
           isMonetory: true,
           language: Language.nepali,
           inWords: true,
         ).format(123456789.6548),
         '१२ करोड ३४ लाख ५६ हजार ७ सय ८९ रुपैया ६५ पैसा',
+      ),
+    );
+  });
+
+  group('hide comma tests:', () {
+    test(
+      'default is english',
+          () => expect(NepaliNumberFormat(hideComma: true).format(1234), '1234'),
+    );
+    test(
+      'formats in nepali',
+          () => expect(
+        NepaliNumberFormat(language: Language.nepali, hideComma: true)
+            .format(1234),
+        '१२३४',
       ),
     );
   });

--- a/test/nepali_number_format_test.dart
+++ b/test/nepali_number_format_test.dart
@@ -10,18 +10,18 @@ void main() {
 
     test(
       'throws error on bool',
-          () => expect(() => _format(true), throwsArgumentError),
+      () => expect(() => _format(true), throwsArgumentError),
     );
   });
 
   group('language tests:', () {
     test(
       'default is english',
-          () => expect(NepaliNumberFormat().format(1234), '1,234'),
+      () => expect(NepaliNumberFormat().format(1234), '1,234'),
     );
     test(
       'formats in nepali',
-          () => expect(
+      () => expect(
         NepaliNumberFormat(language: Language.nepali).format(1234),
         '१,२३४',
       ),
@@ -31,17 +31,17 @@ void main() {
   group('decimal digit tests:', () {
     test(
       'default is 0 for integer input',
-          () => expect(NepaliNumberFormat().format(1234), '1,234'),
+      () => expect(NepaliNumberFormat().format(1234), '1,234'),
     );
 
     test(
       'default is 2 for input type other than integer',
-          () => expect(NepaliNumberFormat().format(1234.0), '1,234.00'),
+      () => expect(NepaliNumberFormat().format(1234.0), '1,234.00'),
     );
 
     test(
       'formats decimal digits as per the decimalDigits value',
-          () => expect(
+      () => expect(
         NepaliNumberFormat(decimalDigits: 4).format(1234),
         '1,234.0000',
       ),
@@ -103,7 +103,7 @@ void main() {
   group('Formats in word tests:', () {
     test(
       'english language',
-          () => expect(
+      () => expect(
         NepaliNumberFormat(
           language: Language.english,
           inWords: true,
@@ -114,7 +114,7 @@ void main() {
 
     test(
       'nepali language',
-          () => expect(
+      () => expect(
         NepaliNumberFormat(
           isMonetory: true,
           language: Language.nepali,
@@ -128,11 +128,11 @@ void main() {
   group('hide comma tests:', () {
     test(
       'default is english',
-          () => expect(NepaliNumberFormat(hideComma: true).format(1234), '1234'),
+      () => expect(NepaliNumberFormat(hideComma: true).format(1234), '1234'),
     );
     test(
       'formats in nepali',
-          () => expect(
+      () => expect(
         NepaliNumberFormat(language: Language.nepali, hideComma: true)
             .format(1234),
         '१२३४',

--- a/test/nepali_number_format_test.dart
+++ b/test/nepali_number_format_test.dart
@@ -125,32 +125,43 @@ void main() {
     );
   });
 
-  group('hide comma tests:', () {
+  group('delimiter default tests:', () {
     test(
-      'default is english',
+      'in english',
+      () => expect(NepaliNumberFormat().format(1234), '1,234'),
+    );
+    test(
+      'in nepali',
+      () => expect(
+        NepaliNumberFormat(language: Language.nepali).format(1234),
+        '१,२३४',
+      ),
+    );
+  });
+
+  group('delimiter tests:', () {
+    test(
+      'using empty delimiter in English',
       () => expect(NepaliNumberFormat(delimiter: '').format(1234), '1234'),
     );
     test(
-      'formats in nepali',
+      'using empty delimiter in English',
       () => expect(
         NepaliNumberFormat(language: Language.nepali, delimiter: '')
             .format(1234),
         '१२३४',
       ),
     );
-  });
-
-  group('hide comma tests:', () {
     test(
-      'default is english',
-      () => expect(NepaliNumberFormat(delimiter: '*').format(1234), '1*234'),
+      'using . delimiter in English',
+      () => expect(NepaliNumberFormat(delimiter: '.').format(1234), '1.234'),
     );
     test(
-      'formats in nepali',
+      'using . delimiter in Nepali',
       () => expect(
-        NepaliNumberFormat(language: Language.nepali, delimiter: '*')
+        NepaliNumberFormat(language: Language.nepali, delimiter: '.')
             .format(1234),
-        '१*२३४',
+        '१.२३४',
       ),
     );
   });


### PR DESCRIPTION
> heading('With Empty Delimiter');
  print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
  print('1234 -> ${currencyFormatWithNoDelimiter.format(1234)}');
  print('12345 -> ${currencyFormatWithNoDelimiter.format(12345)}');
  print('123456 -> ${currencyFormatWithNoDelimiter.format(123456)}');
  print('123456789.6548 -> ${delimiterWithDecimal.format(123456789.6548)}');

> heading('With Delimiter');
  print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');
  print('1234 -> ${currencyFormatWithDelimiter.format(1234)}');
  print('12345 -> ${currencyFormatWithDelimiter.format(12345)}');
  print('123456 -> ${currencyFormatWithDelimiter.format(123456)}');
  print( '1234567.891 -> ${currencyFormatWithDelimiterAndDecimal.format(1234567.891)}');

  
![image](https://user-images.githubusercontent.com/9285916/146313798-325e40c3-3b74-48c8-b278-72c8f2ffa1d6.png)
