### PR TITLE
Month and Days Arithmetic

### DIFF
--- a/lib/src/nepali_date_time.dart
+++ b/lib/src/nepali_date_time.dart
@@ -63,7 +63,59 @@ extension ENepaliDateTime on DateTime {
 /// An instant in time, such as Mangsir 05, 2076, 11:05am
 class NepaliDateTime implements DateTime {
   /// Constructs a NepaliDateTime instance specified.
-  NepaliDateTime(
+  factory NepaliDateTime(
+    int year, [
+    int month = 1,
+    int day = 1,
+    int hour = 0,
+    int minute = 0,
+    int second = 0,
+    int millisecond = 0,
+    int microsecond = 0,
+  ]) {
+    // Adjusting month
+    if (month > 12) {
+      year += (month - 1) ~/ 12;
+      month = (month - 1) % 12 + 1;
+    } else if (month < 1) {
+      year -= month.abs() ~/ 12 + 1;
+      month = 12 - month.abs() % 12;
+    }
+    // Adjusting day
+    while (true) {
+      final currentMonthDays = _getMonthList(year)[month];
+      if (day > 0 && day <= currentMonthDays) {
+        break;
+      }
+      if (day > currentMonthDays) {
+        day -= currentMonthDays;
+        if (++month > 12) {
+          month = 1;
+          year++;
+        }
+      } else if (day < 1) {
+        if (--month < 1) {
+          month = 12;
+          year--;
+        }
+        day += _getMonthList(year)[month];
+      }
+    }
+
+    return NepaliDateTime._internal(
+      year,
+      month,
+      day,
+      hour,
+      minute,
+      second,
+      millisecond,
+      microsecond,
+    );
+  }
+
+  /// Constructs a NepaliDateTime instance specified.
+  NepaliDateTime._internal(
     this.year, [
     this.month = 1,
     this.day = 1,
@@ -400,6 +452,20 @@ class NepaliDateTime implements DateTime {
   @Deprecated('Non operational')
   @override
   DateTime toUtc() => throw UnimplementedError();
+}
+
+List<int> _getMonthList(int year) {
+  final list = _nepaliYears[year];
+  if (list == null) {
+    throw RangeError.range(
+      year,
+      1969,
+      2250,
+      'Unsupported year',
+      'Supported year is 1970-2250',
+    );
+  }
+  return list;
 }
 
 const Map<int, List<int>> _nepaliYears = {

--- a/test/nepali_date_time_test.dart
+++ b/test/nepali_date_time_test.dart
@@ -1,0 +1,187 @@
+import 'package:nepali_utils/src/nepali_date_time.dart';
+import 'package:test/test.dart';
+
+void main() {
+  bool dateEquals(NepaliDateTime actual, NepaliDateTime expected) {
+    final isEqual = actual.year == expected.year &&
+        actual.month == expected.month &&
+        actual.day == expected.day;
+    return isEqual;
+  }
+
+  group('supports days arithmetic', () {
+    test('forward same year', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 5, 37),
+          NepaliDateTime(2081, 5).add(const Duration(days: 36)),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2070, 12, 365),
+          NepaliDateTime(2070, 12).add(const Duration(days: 364)),
+        ),
+        isTrue,
+      );
+    });
+    test('forward next year', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 5, 1000),
+          NepaliDateTime(2081, 5).add(const Duration(days: 999)),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2065, 12, 36),
+          NepaliDateTime(2065, 12).add(const Duration(days: 35)),
+        ),
+        isTrue,
+      );
+    });
+    test('backward same year', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 5, -37),
+          NepaliDateTime(2081, 5).subtract(const Duration(days: 38)),
+        ),
+        isTrue,
+      );
+      expect(
+        NepaliDateTime(2081, 5, -37).toString(),
+        NepaliDateTime(2081, 5).subtract(const Duration(days: 38)).toString(),
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2070, 12, -330),
+          NepaliDateTime(2070, 12).subtract(const Duration(days: 331)),
+        ),
+        isTrue,
+      );
+    });
+    test('backward previous year', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2023, 1, 0),
+          NepaliDateTime(2023).subtract(const Duration(days: 1)),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 1, -37),
+          NepaliDateTime(2081).subtract(const Duration(days: 38)),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2070, 12, -568),
+          NepaliDateTime(2070, 12).subtract(const Duration(days: 569)),
+        ),
+        isTrue,
+      );
+    });
+    test('throws range error', () {
+      expect(
+        () => NepaliDateTime(2248, 12, 876),
+        throwsRangeError,
+      );
+      expect(
+        () => NepaliDateTime(1970, 3, -1234),
+        throwsRangeError,
+      );
+    });
+  });
+
+  group('supports month arithmetic', () {
+    test('forward next years', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 16, 5),
+          NepaliDateTime(2082, 4, 5),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(1998, 123, 25),
+          NepaliDateTime(2008, 3, 25),
+        ),
+        isTrue,
+      );
+    });
+    test('backward previous years', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 0, 5),
+          NepaliDateTime(2080, 12, 5),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2056, -107, 5),
+          NepaliDateTime(2047, 1, 5),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2008, -123, 25),
+          NepaliDateTime(1997, 9, 25),
+        ),
+        isTrue,
+      );
+    });
+    test('throws range error', () {
+      expect(
+        () => NepaliDateTime(2248, 65, 4),
+        throwsRangeError,
+      );
+      expect(
+        () => NepaliDateTime(1973, -243, 23),
+        throwsRangeError,
+      );
+    });
+  });
+  group('supports combined month and day arithmetic', () {
+    test('both positive', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2081, 16, 45),
+          NepaliDateTime(2082, 5, 13),
+        ),
+        isTrue,
+      );
+    });
+    test('both negative', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2056, -107, -1),
+          NepaliDateTime(2046, 12, 30),
+        ),
+        isTrue,
+      );
+    });
+    test('mixed positive and negative', () {
+      expect(
+        dateEquals(
+          NepaliDateTime(2065, 13, -30),
+          NepaliDateTime(2065, 12),
+        ),
+        isTrue,
+      );
+      expect(
+        dateEquals(
+          NepaliDateTime(2065, -11, 1825),
+          NepaliDateTime(2068, 12, 29),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/nepali_date_time_test.dart
+++ b/test/nepali_date_time_test.dart
@@ -3,10 +3,9 @@ import 'package:test/test.dart';
 
 void main() {
   bool dateEquals(NepaliDateTime actual, NepaliDateTime expected) {
-    final isEqual = actual.year == expected.year &&
+    return actual.year == expected.year &&
         actual.month == expected.month &&
         actual.day == expected.day;
-    return isEqual;
   }
 
   group('supports days arithmetic', () {

--- a/test/nepali_number_format_test.dart
+++ b/test/nepali_number_format_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     test(
       'default is 2 for input type other than integer',
-      () => expect(NepaliNumberFormat().format(1234), '1,234.00'),
+      () => expect(NepaliNumberFormat().format('1234'), '1,234.00'),
     );
 
     test(


### PR DESCRIPTION
This PR adds feature to accept month values above or beyond the range of 1 to 12 and the day value less than 1 or greater than the days in given month.