### PR TITLE
Using Instant-based conversion for converting DateTime into NepaliDateTime

### DIFF
--- a/lib/src/nepali_date_time.dart
+++ b/lib/src/nepali_date_time.dart
@@ -5,6 +5,9 @@
 import 'package:nepali_utils/src/language.dart';
 import 'package:nepali_utils/src/nepali_date_format.dart';
 
+/// Reference instant: Nepali 1970-01-01 00:00:00 = 1913-04-13 00:00 Nepal time = 1913-04-12 18:15:00 UTC.
+final DateTime _nepaliEpochUtc = DateTime.utc(1913, 4, 12, 18, 15, 0);
+
 ///
 extension ENepaliDateTime on DateTime {
   /// Converts the [DateTime] to [NepaliDateTime].
@@ -56,6 +59,51 @@ extension ENepaliDateTime on DateTime {
       now.second,
       now.millisecond,
       now.microsecond,
+    );
+  }
+
+  /// Converts this [DateTime] to [NepaliDateTime] using the full instant (date + time).
+  ///
+  /// Unlike [toNepaliDateTime], this uses the input time for conversion: the day
+  /// count is derived from the exact UTC instant relative to the Nepali epoch,
+  /// so there is no off-by-one day error near midnight or across timezones.
+  /// Prefer this when you need consistent results regardless of timezone or time of day.
+  NepaliDateTime toNepaliDateTimeFromInstant() {
+    const nepalTzOffset = Duration(hours: 5, minutes: 45);
+    final inputUtc = toUtc();
+    final inNepalTime = inputUtc.add(nepalTzOffset);
+
+    var difference = inputUtc.difference(_nepaliEpochUtc).inDays;
+
+    var nepaliYear = 1970;
+    var nepaliMonth = 1;
+    var nepaliDay = 1;
+
+    var daysInYear = _nepaliYears[nepaliYear]!.first;
+    while (difference >= daysInYear) {
+      nepaliYear += 1;
+      difference -= daysInYear;
+      daysInYear = _nepaliYears[nepaliYear]!.first;
+    }
+
+    var daysInMonth = _nepaliYears[nepaliYear]![nepaliMonth];
+    while (difference >= daysInMonth) {
+      difference -= daysInMonth;
+      nepaliMonth += 1;
+      daysInMonth = _nepaliYears[nepaliYear]![nepaliMonth];
+    }
+
+    nepaliDay += difference;
+
+    return NepaliDateTime(
+      nepaliYear,
+      nepaliMonth,
+      nepaliDay,
+      inNepalTime.hour,
+      inNepalTime.minute,
+      inNepalTime.second,
+      inNepalTime.millisecond,
+      inNepalTime.microsecond,
     );
   }
 }

--- a/test/nepali_date_time_instant_test.dart
+++ b/test/nepali_date_time_instant_test.dart
@@ -1,0 +1,101 @@
+import 'package:nepali_utils/nepali_utils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DateTime <-> NepaliDateTime instant-based conversion', () {
+    test('round-trips AD dates via instant-based conversion for a wide range', () {
+      const nepalTzOffset = Duration(hours: 5, minutes: 45);
+
+      // Chosen to cover the full supported Nepali calendar range.
+      for (var year = 1913; year <= 2100; year++) {
+        for (var month = 1; month <= 12; month++) {
+          final maxDay = _daysInGregorianMonth(year, month);
+          for (var day = 1; day <= maxDay; day++) {
+            // This represents 00:00 in Nepal for the given AD date.
+            final adNepalMidnightUtc = DateTime.utc(year, month, day).subtract(nepalTzOffset);
+
+            final bs = adNepalMidnightUtc.toNepaliDateTimeFromInstant();
+
+            final adBack = bs.toDateTime();
+
+            expect(
+              adBack.year,
+              year,
+              reason: 'Year mismatch for AD date $year-$month-$day',
+            );
+            expect(
+              adBack.month,
+              month,
+              reason: 'Month mismatch for AD date $year-$month-$day',
+            );
+            expect(
+              adBack.day,
+              day,
+              reason: 'Day mismatch for AD date $year-$month-$day',
+            );
+          }
+        }
+      }
+    });
+
+    test('round-trips BS dates via AD and instant-based conversion for a wide range', () {
+      // Use a broad but bounded range within the supported BS years.
+      for (var year = 1970; year <= 2100; year++) {
+        for (var month = 1; month <= 12; month++) {
+          final daysInMonth = NepaliDateTime(year, month, 1).totalDays;
+          for (var day = 1; day <= daysInMonth; day++) {
+            final bs = NepaliDateTime(year, month, day);
+
+            final ad = bs.toDateTime();
+            final bsBack = ad.toNepaliDateTimeFromInstant();
+
+            expect(
+              bsBack.year,
+              year,
+              reason: 'BS year mismatch for BS date $year-$month-$day',
+            );
+            expect(
+              bsBack.month,
+              month,
+              reason: 'BS month mismatch for BS date $year-$month-$day',
+            );
+            expect(
+              bsBack.day,
+              day,
+              reason: 'BS day mismatch for BS date $year-$month-$day',
+            );
+          }
+        }
+      }
+    });
+  });
+}
+
+int _daysInGregorianMonth(int year, int month) {
+  const monthLengths = <int>[
+    31,
+    28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+
+  if (month == 2 && _isLeapYear(year)) {
+    return 29;
+  }
+
+  return monthLengths[month - 1];
+}
+
+bool _isLeapYear(int year) {
+  if (year % 400 == 0) return true;
+  if (year % 100 == 0) return false;
+  return year % 4 == 0;
+}


### PR DESCRIPTION
The new implementation calculates the BS date using a fixed UTC epoch (1913-04-12 18:15:00Z) and pure UTC day differences, instead of relying on local civil dates. This eliminates rare but critical off-by-one day errors caused by historical timezone anomalies (e.g., Nepal’s 1986 offset change) and irregular day lengths.